### PR TITLE
Flatfile configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 pghoney
 captures/
+*.conf

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
-	"strings"
 	"syscall"
 
 	log "github.com/Sirupsen/logrus"
@@ -19,11 +18,11 @@ func init() {
 
 func main() {
 	type Configuration struct {
-		Port          int    `json:"port"`
-		Address       string `json:"address"`
-		PgUsers       string `json:"pgUsers"`
-		Debug         bool   `json:"debug"`
-		Cleartext     bool   `json:"cleartext"`
+		Port          int      `json:"port"`
+		Address       string   `json:"address"`
+		PgUsers       []string `json:"pgUsers"`
+		Debug         bool     `json:"debug"`
+		Cleartext     bool     `json:"cleartext"`
 		HpFeedsConfig `json:"hpfeedsConfig"`
 	}
 	var config Configuration
@@ -61,7 +60,7 @@ func main() {
 	postgresServer := NewPostgresServer(
 		port,
 		addr,
-		strings.Split(pgUsers, ","),
+		pgUsers,
 		cleartext,
 		hpfeedsChannel,
 		hpFeedsConfig.Enabled,

--- a/main.go
+++ b/main.go
@@ -18,11 +18,12 @@ func init() {
 
 func main() {
 	type Configuration struct {
-		Port      string
-		Address   string
-		PgUsers   string
-		Debug     bool
-		Cleartext bool
+		Port          string `json:"port"`
+		Address       string `json:"address"`
+		PgUsers       string `json:"pgUsers"`
+		Debug         bool   `json:"debug"`
+		Cleartext     bool   `json:"cleartext"`
+		HpFeedsConfig `json:"hpfeedsConfig"`
 	}
 	var config Configuration
 

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -18,7 +19,7 @@ func init() {
 
 func main() {
 	type Configuration struct {
-		Port          string `json:"port"`
+		Port          int    `json:"port"`
 		Address       string `json:"address"`
 		PgUsers       string `json:"pgUsers"`
 		Debug         bool   `json:"debug"`
@@ -40,7 +41,7 @@ func main() {
 		panic(err)
 	}
 
-	port := config.Port
+	port := strconv.Itoa(config.Port)
 	addr := config.Address
 	pgUsers := config.PgUsers
 	debug := config.Debug

--- a/main.go
+++ b/main.go
@@ -25,13 +25,9 @@ func init() {
 	log.SetLevel(log.InfoLevel)
 }
 
-func main() {
+func configurationFrom(configFile string) Configuration {
 	var config Configuration
-
-	configFile := flag.String("config", "pghoney.conf", "JSON configuration file")
-	flag.Parse()
-
-	jsonConfig, err := ioutil.ReadFile(*configFile)
+	jsonConfig, err := ioutil.ReadFile(configFile)
 	if err != nil {
 		panic(err)
 	}
@@ -40,6 +36,14 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+
+	return config
+}
+
+func main() {
+	configFile := flag.String("config", "pghoney.conf", "JSON configuration file")
+	flag.Parse()
+	config := configurationFrom(*configFile)
 
 	port := strconv.Itoa(config.Port)
 	addr := config.Address

--- a/main.go
+++ b/main.go
@@ -29,12 +29,12 @@ func configurationFrom(configFile string) Configuration {
 	var config Configuration
 	jsonConfig, err := ioutil.ReadFile(configFile)
 	if err != nil {
-		panic(err)
+		log.Fatalf("Couldn't %s", err)
 	}
 
 	err = json.Unmarshal(jsonConfig, &config)
 	if err != nil {
-		panic(err)
+		log.Fatalf("Couldn't parse JSON in %s: %s", configFile, err)
 	}
 
 	return config

--- a/main.go
+++ b/main.go
@@ -12,19 +12,20 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
+type Configuration struct {
+	Port          int      `json:"port"`
+	Address       string   `json:"address"`
+	PgUsers       []string `json:"pgUsers"`
+	Debug         bool     `json:"debug"`
+	Cleartext     bool     `json:"cleartext"`
+	HpFeedsConfig `json:"hpfeedsConfig"`
+}
+
 func init() {
 	log.SetLevel(log.InfoLevel)
 }
 
 func main() {
-	type Configuration struct {
-		Port          int      `json:"port"`
-		Address       string   `json:"address"`
-		PgUsers       []string `json:"pgUsers"`
-		Debug         bool     `json:"debug"`
-		Cleartext     bool     `json:"cleartext"`
-		HpFeedsConfig `json:"hpfeedsConfig"`
-	}
 	var config Configuration
 
 	configFile := flag.String("config", "pghoney.conf", "JSON configuration file")

--- a/main.go
+++ b/main.go
@@ -50,12 +50,11 @@ func main() {
 		log.SetLevel(log.DebugLevel)
 	}
 
-	hpFeedsConfig := &HpFeedsConfig{
-		Enabled: false,
-	}
+	hpFeedsConfig := config.HpFeedsConfig
+
 	hpfeedsChannel := make(chan []byte)
 	if hpFeedsConfig.Enabled {
-		go hpfeedsConnect(hpFeedsConfig, hpfeedsChannel)
+		go hpfeedsConnect(&hpFeedsConfig, hpfeedsChannel)
 	}
 
 	postgresServer := NewPostgresServer(

--- a/main.go
+++ b/main.go
@@ -50,12 +50,11 @@ func main() {
 	pgUsers := config.PgUsers
 	debug := config.Debug
 	cleartext := config.Cleartext
+	hpFeedsConfig := config.HpFeedsConfig
 
 	if debug {
 		log.SetLevel(log.DebugLevel)
 	}
-
-	hpFeedsConfig := config.HpFeedsConfig
 
 	hpfeedsChannel := make(chan []byte)
 	if hpFeedsConfig.Enabled {

--- a/pghoney.conf.sample
+++ b/pghoney.conf.sample
@@ -1,7 +1,7 @@
 {
   "port":5432,
   "address":"127.0.0.1",
-  "pgUsers":"postgres",
+  "pgUsers":["postgres"],
   "debug":false,
   "cleartext":false,
   "hpfeedsConfig":{
@@ -10,7 +10,7 @@
     "channel":"pghoney.events",
     "ident":"abc123",
     "secret":"def567",
-    "enabled":false
+    "enabled":true
   }
 }
 

--- a/pghoney.conf.sample
+++ b/pghoney.conf.sample
@@ -1,5 +1,5 @@
 {
-  "port":"5432",
+  "port":5432,
   "address":"127.0.0.1",
   "pgUsers":"postgres",
   "debug":false,

--- a/pghoney.conf.sample
+++ b/pghoney.conf.sample
@@ -1,8 +1,16 @@
 {
-  "Port":"5432",
-  "Address":"127.0.0.1",
-  "PgUsers":"postgres",
-  "Debug":false,
-  "Cleartext":false
+  "port":"5432",
+  "address":"127.0.0.1",
+  "pgUsers":"postgres",
+  "debug":false,
+  "cleartext":false,
+  "hpfeedsConfig":{
+    "port":10000,
+    "host":"127.0.0.1",
+    "channel":"pghoney.events",
+    "ident":"abc123",
+    "secret":"def567",
+    "enabled":false
+  }
 }
 

--- a/pghoney.conf.sample
+++ b/pghoney.conf.sample
@@ -1,0 +1,8 @@
+{
+  "Port":"5432",
+  "Address":"127.0.0.1",
+  "PgUsers":"postgres",
+  "Debug":false,
+  "Cleartext":false
+}
+


### PR DESCRIPTION
This PR:
1. Uses a JSON file to read configuration options
2. Replaces CLI interface with the JSON file from (1) (there's -c for specifying that conf, though)
3. Reads HPF configuration from that file, too
4. Normalizes the structs involved so that `port` is always an `int`