### PR TITLE
Return error on invalid handshake

### DIFF
--- a/server.go
+++ b/server.go
@@ -169,7 +169,7 @@ func (p *PostgresServer) handleStartup(buff readBuf, conn net.Conn) bool {
 	buf := readBuf(buff)
 	// Read out the initial two numbers so we are just left with the k/v pairs.
 	actualLength := indexOfLastFilledByte(buf) + 1
-	claimedLength := int(buf.int32())
+	claimedLength := buf.int32()
 
 	if (actualLength == -1) || (claimedLength != actualLength) {
 		log.Debugf("Invalid handshake request received from %s, ", conn.RemoteAddr())

--- a/server.go
+++ b/server.go
@@ -171,7 +171,7 @@ func (p *PostgresServer) handleStartup(buff readBuf, conn net.Conn) bool {
 	actualLength := indexOfLastFilledByte(buf) + 1
 	claimedLength := buf.int32()
 
-	if (actualLength == -1) || (claimedLength != actualLength) {
+	if (actualLength == 0) || (claimedLength != actualLength) {
 		log.Debugf("Invalid handshake request received from %s, ", conn.RemoteAddr())
 		log.Debugf("claimed length: %d, actual length: %d", claimedLength, actualLength)
 		conn.Write(handshakeErrorResponse())


### PR DESCRIPTION
It's the same error every time (see also: sticky_elephant), but it gets us this:

```
ffleming@fsf-home pghoney fsf/error % nmap -p 5432 127.0.0.1 -sV

Starting Nmap 7.40 ( https://nmap.org ) at 2017-03-30 20:36 PDT
Nmap scan report for localhost (127.0.0.1)
Host is up (0.00026s latency).
PORT     STATE SERVICE    VERSION
5432/tcp open  postgresql PostgreSQL DB 9.5.5

Service detection performed. Please report any incorrect results at https://nmap.org/submit/ .
Nmap done: 1 IP address (1 host up) scanned in 15.51 seconds
```